### PR TITLE
refactor: remove useless version

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -1,7 +1,6 @@
 openapi: 3.0.3
 info:
   title: OpenAPI schema for template rds-seeder
-  version: v0.0.1
 components:
   schemas:
     variables:


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
OpenAPI info version is useless and confusing.

**Solution:**
Not require the version and skip validate it while user customizes the UI schema

**Related Issue:**
#1306

